### PR TITLE
Update travelRestrictions.json

### DIFF
--- a/src/data/travelRestrictions.json
+++ b/src/data/travelRestrictions.json
@@ -5,619 +5,619 @@
         "code": "al",
         "name": "albania",
         "emoji": "🇦🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "dz",
         "name": "algeria",
         "emoji": "🇩🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ad",
         "name": "andorra",
         "emoji": "🇦🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ag",
         "name": "antiguaandbarbuda",
         "emoji": "🇦🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "am",
         "name": "armenia",
         "emoji": "🇦🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "au",
         "name": "australia",
         "emoji": "🇦🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "at",
         "name": "austria",
         "emoji": "🇦🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bh",
         "name": "bahrain",
         "emoji": "🇧🇭",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bb",
         "name": "barbados",
         "emoji": "🇧🇧",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "by",
         "name": "belarus",
         "emoji": "🇧🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "be",
         "name": "belgium",
         "emoji": "🇧🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bo",
         "name": "bolivia",
         "emoji": "🇧🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ba",
         "name": "bosniaherzegovina",
         "emoji": "🇧🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "br",
         "name": "brazil",
         "emoji": "🇧🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bn",
         "name": "brunei",
         "emoji": "🇧🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bg",
         "name": "bulgaria",
         "emoji": "🇧🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cm",
         "name": "cameroon",
         "emoji": "🇨🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ca",
         "name": "canada",
         "emoji": "🇨🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cf",
         "name": "central african republic",
         "emoji": "🇨🇫",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cn",
         "name": "china",
         "emoji": "🇨🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cl",
         "name": "chile",
         "emoji": "🇨🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cd",
         "name": "congo-kinshasa",
         "emoji": "🇨🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cr",
         "name": "costa rica",
         "emoji": "🇨🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ci",
         "name": "cotedivoire",
         "emoji": "🇨🇮",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "hr",
         "name": "croatia",
         "emoji": "🇭🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cu",
         "name": "cuba",
         "emoji": "🇨🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cy",
         "name": "cyprus",
         "emoji": "🇨🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cz",
         "name": "czechrepublic",
         "emoji": "🇨🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "dk",
         "name": "denmark",
         "emoji": "🇩🇰",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "dj",
         "name": "djibouti",
         "emoji": "🇩🇯",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "dm",
         "name": "dominica",
         "emoji": "🇩🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "do",
         "name": "dominicanrepublic",
         "emoji": "🇩🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ec",
         "name": "ecuador",
         "emoji": "🇪🇨",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "eg",
         "name": "egypt",
         "emoji": "🇪🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ee",
         "name": "estonia",
         "emoji": "🇪🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sz",
         "name": "eswantini",
         "emoji": "🇸🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "fi",
         "name": "finland",
         "emoji": "🇫🇮",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "fr",
         "name": "france",
         "emoji": "🇫🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "de",
         "name": "germany",
         "emoji": "🇩🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ge",
         "name": "georgia",
         "emoji": "🇬🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gr",
         "name": "greece",
         "emoji": "🇬🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gd",
         "name": "grenada",
         "emoji": "🇬🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gt",
         "name": "guatemala",
         "emoji": "🇬🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gy",
         "name": "guyana",
         "emoji": "🇬🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ht",
         "name": "haiti",
         "emoji": "🇭🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "hu",
         "name": "hungary",
         "emoji": "🇭🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "is",
         "name": "iceland",
         "emoji": "🇮🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "id",
         "name": "indonesia",
         "emoji": "🇮🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ir",
         "name": "iran",
         "emoji": "🇮🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "iq",
         "name": "iraq",
         "emoji": "🇮🇶",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ie",
         "name": "ireland",
         "emoji": "🇮🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "il",
         "name": "israel",
         "emoji": "🇮🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "it",
         "name": "italy",
         "emoji": "🇮🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "jm",
         "name": "jamaica",
         "emoji": "🇯🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "kr",
         "name": "korea",
         "emoji": "🇰🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "xk",
         "name": "kosovo",
         "emoji": "🇽🇰",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "kw",
         "name": "kuwait",
         "emoji": "🇰🇼",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "lv",
         "name": "latvia",
         "emoji": "🇱🇻",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "lb",
         "name": "lebanon",
         "emoji": "🇱🇧",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "li",
         "name": "liechtenstein",
         "emoji": "🇱🇮",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "lt",
         "name": "lithuania",
         "emoji": "🇱🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "lu",
         "name": "luxembourg",
         "emoji": "🇱🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "my",
         "name": "malaysia",
         "emoji": "🇲🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mt",
         "name": "malta",
         "emoji": "🇲🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mr",
         "name": "mauritania",
         "emoji": "🇲🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mu",
         "name": "mauritius",
         "emoji": "🇲🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "md",
         "name": "moldova",
         "emoji": "🇲🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mc",
         "name": "monaco",
         "emoji": "🇲🇨",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "me",
         "name": "montenegro",
         "emoji": "🇲🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ma",
         "name": "morocco",
         "emoji": "🇲🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "nl",
         "name": "netherlands",
         "emoji": "🇳🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "nz",
         "name": "newzealand",
         "emoji": "🇳🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ni",
         "name": "nicaragua",
         "emoji": "🇳🇮",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mk",
         "name": "northmacedonia",
         "emoji": "🇲🇰",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "no",
         "name": "norway",
         "emoji": "🇳🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "om",
         "name": "oman",
         "emoji": "🇴🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "pa",
         "name": "panama",
         "emoji": "🇵🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "pe",
         "name": "peru",
         "emoji": "🇵🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ph",
         "name": "philippines",
         "emoji": "🇵🇭",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "pl",
         "name": "poland",
         "emoji": "🇵🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "pt",
         "name": "portugal",
         "emoji": "🇵🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "qa",
         "name": "qatar",
         "emoji": "🇶🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ro",
         "name": "romania",
         "emoji": "🇷🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ru",
         "name": "russia",
         "emoji": "🇷🇺",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sm",
         "name": "sanmarino",
         "emoji": "🇸🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "kn",
         "name": "saintkittsandnevis",
         "emoji": "🇰🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sa",
         "name": "saudiarabia",
         "emoji": "🇸🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "rs",
         "name": "serbia",
         "emoji": "🇷🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "vc",
         "name": "saint vincent and the grenadines",
         "emoji": "🇻🇨",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sn",
         "name": "senegal",
         "emoji": "🇸🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sg",
         "name": "singapore",
         "emoji": "🇸🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sk",
         "name": "slovakia",
         "emoji": "🇸🇰",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "si",
         "name": "slovenia",
         "emoji": "🇸🇮",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "es",
         "name": "spain",
         "emoji": "🇪🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "se",
         "name": "sweden",
         "emoji": "🇸🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ch",
         "name": "switzerland",
         "emoji": "🇨🇭",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "tw",
         "name": "taiwan",
         "emoji": "🇹🇼",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "th",
         "name": "thailand",
         "emoji": "🇹🇭",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "tr",
         "name": "turkey",
         "emoji": "🇹🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gb",
         "name": "uk",
         "emoji": "🇬🇧",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ua",
         "name": "ukraine",
         "emoji": "🇺🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ae",
         "name": "unitedarabemirates",
         "emoji": "🇦🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "us",
         "name": "usa",
         "emoji": "🇺🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "va",
@@ -629,259 +629,259 @@
         "code": "vn",
         "name": "vietnam",
         "emoji": "🇻🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "westerdam",
         "name": "westerdam",
         "emoji": "🛳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mx",
         "name": "mexico",
-        "link": "http://www.moj.go.jp/content/001316999.pdf",
+        "link": "http://www.moj.go.jp/content/001329914.pdf",
         "emoji": "🇲🇽"
       },
       {
         "code": "az",
         "name": "azerbaijan",
-        "link": "http://www.moj.go.jp/content/001316999.pdf",
+        "link": "http://www.moj.go.jp/content/001329914.pdf",
         "emoji": "🇦🇿"
       },
       {
         "code": "bs",
         "name": "bahamas",
         "emoji": "🇧🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cv",
         "name": "caboverde",
         "emoji": "🇨🇻",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "co",
         "name": "colombia",
         "emoji": "🇨🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gq",
         "name": "equatorialguinea",
         "emoji": "🇬🇶",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ga",
         "name": "gabon",
         "emoji": "🇬🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gw",
         "name": "guineabissau",
         "emoji": "🇬🇼",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "hn",
         "name": "honduras",
         "emoji": "🇭🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "kz",
         "name": "kazakhstan",
         "emoji": "🇰🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mv",
         "name": "maldives",
         "emoji": "🇲🇻",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "st",
         "name": "saotomeandprincipe",
         "emoji": "🇸🇹",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "uy",
         "name": "uruguay",
         "emoji": "🇺🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "af",
         "name": "afghanistan",
         "emoji": "🇦🇫",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ar",
         "name": "argentina",
         "emoji": "🇦🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "in",
         "name": "india",
         "emoji": "🇮🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sv",
         "name": "el salvador",
         "emoji": "🇸🇻",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gh",
         "name": "ghana",
         "emoji": "🇬🇭",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "gn",
         "name": "guinea",
         "emoji": "🇬🇳",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "kg",
         "name": "kyrgyzstan",
         "emoji": "🇰🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "tj",
         "name": "tajikistan",
         "emoji": "🇹🇯",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "pk",
         "name": "pakistan",
         "emoji": "🇵🇰",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bd",
         "name": "bangladesh",
         "emoji": "🇧🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "za",
         "name": "south africa",
         "emoji": "🇿🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "bw",
         "name": "botswana",
         "emoji": "🇧🇼",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "km",
         "name": "comoros",
         "emoji": "🇰🇲",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ke",
         "name": "kenya",
         "emoji": "🇰🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "lr",
         "name": "liberia",
         "emoji": "🇱🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ly",
         "name": "libya",
         "emoji": "🇱🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "mg",
         "name": "madagascar",
         "emoji": "🇲🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "na",
         "name": "namibia",
         "emoji": "🇳🇦",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "np",
         "name": "nepal",
         "emoji": "🇳🇵",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ps",
         "name": "palestine",
         "emoji": "🇵🇸",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "py",
         "name": "paraguay",
         "emoji": "🇵🇾",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "cd",
         "name": "republic of congo",
         "emoji": "🇨🇬",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sl",
         "name": "sierra leone",
         "emoji": "🇸🇱",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "so",
         "name": "somalia",
         "emoji": "🇸🇴",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sd",
         "name": "sudan",
         "emoji": "🇸🇩",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "sr",
         "name": "suriname",
         "emoji": "🇸🇷",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "uz",
         "name": "uzbekistan",
         "emoji": "🇺🇿",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       },
       {
         "code": "ve",
         "name": "venezuela",
         "emoji": "🇻🇪",
-        "link": "http://www.moj.go.jp/content/001316999.pdf"
+        "link": "http://www.moj.go.jp/content/001329914.pdf"
       }
     ],
     "visaRequired": [],


### PR DESCRIPTION
tagging @reustle - as indicated in the issue submitted by @tassoman the pdf file pointed to by the link http://www.moj.go.jp/content/001316999.pdf doesn't exist anymore, I was able to find the updated PDF which has the travel restrictions updated up to August 30, 2020 http://www.moj.go.jp/content/001329914.pdf - there are new countries added on the updated PDF and their names, flags and country codes can be added to this JSON file via another pull request

// Please tag @reustle in your newly created PR

// Please include a screenshot of any visual changes you've made
